### PR TITLE
parse_grants.py edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.pyc
+grant_files/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 *.pyc
-grant_files/*

--- a/grant_files/.gitignore
+++ b/grant_files/.gitignore
@@ -1,5 +1,0 @@
-*.zip
-*.txt
-*.html
-*.xml
-*.dat

--- a/grant_files/.gitignore
+++ b/grant_files/.gitignore
@@ -1,0 +1,5 @@
+*.zip
+*.txt
+*.html
+*.xml
+*.dat

--- a/parse_grants.py
+++ b/parse_grants.py
@@ -349,8 +349,9 @@ def store_patent(pat):
         return True
 
     pn = pat['patnum']
+
     i += 1
-    
+
     # store ipcs
     for (ipc, ver) in pat['ipclist']:
         ipc_chunker.insert(pn, ipc, ver)
@@ -371,7 +372,6 @@ def store_patent(pat):
     # limit
     if args.limit and i >= args.limit:
         return False
-
     return True
 
 # collect files
@@ -385,6 +385,12 @@ else:
 
 # parse by generation
 for fpath in file_list:
+
+    # Terminate upon reaching limit
+    if args.limit and i >= args.limit:
+        print("Reached limit.")
+        break
+
     (fdir, fname) = os.path.split(fpath)
     if fname.endswith('.dat'):
         gen = 1

--- a/parse_grants.py
+++ b/parse_grants.py
@@ -348,8 +348,9 @@ def store_patent(pat):
     if not pat['patnum'].isnumeric() or len(pat['owner']) == 0:
         return True
 
+    pn = pat['patnum']
     i += 1
-
+    
     # store ipcs
     for (ipc, ver) in pat['ipclist']:
         ipc_chunker.insert(pn, ipc, ver)


### PR DESCRIPTION
This PR addresses two issues:

1. `pn` was not defined in `store_patent`, causing an error
2. If the target was left as the entire `grant_files` directory, when `parse_grants` reached the user-specified limit, it would continue to iterate through all files, reading a single patent from each of them. Now it will terminate upon reaching the limit.

Thanks for this fantastic code!